### PR TITLE
hostBindMount: add a Source path for mountopts.FixUp

### DIFF
--- a/frontend/gateway/container.go
+++ b/frontend/gateway/container.go
@@ -161,7 +161,7 @@ func PrepareMounts(ctx context.Context, mm *mounts.MountManager, cm cache.Manage
 
 		switch m.MountType {
 		case opspb.MountType_HOST_BIND: //earthly
-			mountable = mm.MountableHostBind()
+			mountable = mm.MountableHostBind(ctx, m)
 
 		case opspb.MountType_BIND:
 			// if mount creates an output


### PR DESCRIPTION
This is a bit of a hacky solution, but it solves the problems with `hostBindMount` (most notably the `/usr/bin/earth_debugger` mount) in unprivileged scenarios - like rootless podman.

I'm going to see if I can find a less hacky solution, but if we can't find one reasonably quickly, this solution works fine and only impacts code that was already earthly-specific.