### PR TITLE
llbsolver: set temporary lease in Commit context

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -579,7 +579,7 @@ func (w *Writer) Discard() {
 func (w *Writer) Commit(ctx context.Context) (*ocispecs.Descriptor, func(), error) {
 	dgst := w.dgstr.Digest()
 	sz := int64(w.sz)
-	if err := w.w.Commit(ctx, int64(w.sz), dgst); err != nil {
+	if err := w.w.Commit(leases.WithLease(ctx, w.l.ID), int64(w.sz), dgst); err != nil {
 		if !errdefs.IsAlreadyExists(err) {
 			w.Discard()
 			return nil, nil, err


### PR DESCRIPTION
The temporary lease must be passed via the context for the call to w.Commit() to prevent the cleanup of metadata resources before they are fully referenced.

This fixes https://github.com/earthly/earthly/issues/3000