### PR TITLE
increase lease duration to prevent GC

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -526,7 +526,7 @@ func (h *HistoryQueue) Delete(ctx context.Context, ref string) error {
 }
 
 func (h *HistoryQueue) OpenBlobWriter(ctx context.Context, mt string) (_ *Writer, err error) {
-	l, err := h.hLeaseManager.Create(ctx, leases.WithRandomID(), leases.WithExpiration(5*time.Minute), leaseutil.MakeTemporary)
+	l, err := h.hLeaseManager.Create(ctx, leases.WithRandomID(), leases.WithExpiration(20*time.Minute), leaseutil.MakeTemporary) // earthly-specific increase lease expiration from 5min to 20min to lower the frequency of unknown blob in history errors
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This attempts to lower the frequency of unknown blob in history errors.