### PR TITLE
keep ResponseHeaderTimeout value for now

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -206,7 +206,7 @@ func newDefaultTransport() *http.Transport {
 		MaxIdleConnsPerHost:   4,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second, // earthly needs this; it was reverted by https://github.com/moby/buildkit/pull/3995 but if it's removed we will regress on reusing a connection that's become invalid/corrupt/bad due to hibernation. If we find a better way to detect those dead connections, we can remove that, however the IdleConnTimeout doesn't invalid it.
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 }


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/3995 will revert our upstream contrib which set this value; it has been reverted, but we don't want to revert it in our fork (until we have a more appropriate fix).