### PR TITLE
Open files for local writes with truncate flag

### DIFF
--- a/session/localhost/localhostprovider/localhostprovider.go
+++ b/session/localhost/localhostprovider/localhostprovider.go
@@ -310,7 +310,7 @@ func receiveFile(stream localhost.Localhost_PutServer) (err error) {
 		return errors.WithStack(err)
 	}
 
-	f, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY, os.FileMode(stat.Mode))
+	f, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(stat.Mode))
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
Without truncate, writing a source file to an existing (larger) destination will result in a "corrupted" file that contains bytes from the source as well as the original destination.

Fixes https://github.com/earthly/earthly/issues/3094