### PR TITLE
Fix buildkit pauses at the end of builds

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -206,7 +206,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 		var releasers []func()
 
 		attrs := map[string]string{
-			"mode":          "max",
+			"mode":          "min", // Earthly specific. We set this to "min" instead of "max" to prevent the slow cache export at the end of a build.
 			"capture-usage": "true",
 		}
 


### PR DESCRIPTION
Looks like the provenance feature does some hard-coded, extensive caching at the end of a build, regardless of if you use the sbom or provenance features.

This option appears to be un-bypassable, and is hard coded. Change it to `min` to avoid the cache delays at the ends of builds.

I've attached a profile. Anecdotally, I have seen some targets that went from ~40s runtime to ~10m runtime on `v0.7.4` go back to their expected durations with this fix. No other immediately apparent reprercussions were seen... but admittedly my testing was not extensive.