### PR TITLE
track actives map usage for use in error reporting

### DIFF
--- a/solver/inconsistent_graph_state_error_tracker.go
+++ b/solver/inconsistent_graph_state_error_tracker.go
@@ -1,0 +1,59 @@
+package solver
+
+// earthly-specific: this is used to collect information related to "inconsistent graph state" errors
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	digest "github.com/opencontainers/go-digest"
+)
+
+var dgstTrackerInst = newDgstTracker()
+
+type dgstTrackerItem struct {
+	dgst   digest.Digest
+	action string
+	seen   time.Time
+}
+
+type dgstTracker struct {
+	head    int
+	records []dgstTrackerItem
+}
+
+func newDgstTracker() *dgstTracker {
+	n := 10000
+	return &dgstTracker{
+		records: make([]dgstTrackerItem, n),
+	}
+}
+
+func (d *dgstTracker) add(dgst digest.Digest, action string) {
+	d.head += 1
+	if d.head >= len(d.records) {
+		d.head = 0
+	}
+	d.records[d.head].dgst = dgst
+	d.records[d.head].action = action
+	d.records[d.head].seen = time.Now()
+}
+
+func (d *dgstTracker) String() string {
+	var sb strings.Builder
+
+	for i := d.head; i >= 0; i-- {
+		if d.records[i].seen.IsZero() {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("%s %s %s; ", d.records[i].dgst, d.records[i].action, d.records[i].seen))
+	}
+	for i := len(d.records) - 1; i > d.head; i-- {
+		if d.records[i].seen.IsZero() {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("%s %s %s; ", d.records[i].dgst, d.records[i].action, d.records[i].seen))
+	}
+	return sb.String()
+}

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -365,6 +365,8 @@ type pipeFactory struct {
 func (pf *pipeFactory) NewInputRequest(ee Edge, req *edgeRequest) pipe.Receiver {
 	target := pf.s.ef.getEdge(ee)
 	if target == nil {
+		dgst := ee.Vertex.Digest()
+		bklog.G(context.TODO()).Errorf("failed to get edge dgst=%s name=%s desiredState=%s; actives history: %s", dgst, ee.Vertex.Name(), req.desiredState, dgstTrackerInst.String()) // earthly-specific
 		return pf.NewFuncRequest(func(_ context.Context) (interface{}, error) {
 			return nil, errors.Errorf("failed to get edge: inconsistent graph state")
 		})


### PR DESCRIPTION
This is to help collect data which can be displayed when an inconsistent graph state error occurs.