### PR TITLE
Support supplying a custom Git sshCommand

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -284,6 +284,10 @@ func Git(url, ref string, opts ...GitOption) State {
 		attrs[pb.AttrGitLogLevel] = fmt.Sprintf("%d", gi.LogLevel)
 		addCap(&gi.Constraints, pb.CapSourceGitLogLevel)
 	}
+	if gi.SSHCommand != "" { // earthly-specific
+		attrs[pb.AttrGitSSHCommand] = gi.SSHCommand
+		addCap(&gi.Constraints, pb.CapSourceGitSSHCommand)
+	}
 	if url != "" {
 		attrs[pb.AttrFullRemoteURL] = url
 		addCap(&gi.Constraints, pb.CapSourceGitFullURL)
@@ -347,6 +351,7 @@ type GitInfo struct {
 	addAuthCap       bool
 	KnownSSHHosts    string
 	MountSSHSock     string
+	SSHCommand       string              // earthly-specific
 	LFSInclude       string              // earthly-specific
 	LogLevel         gitutil.GitLogLevel // earthly-specific
 }
@@ -395,6 +400,12 @@ func KnownSSHHosts(key string) GitOption {
 func MountSSHSock(sshID string) GitOption {
 	return gitOptionFunc(func(gi *GitInfo) {
 		gi.MountSSHSock = sshID
+	})
+}
+
+func SSHCommand(sshCommand string) GitOption {
+	return gitOptionFunc(func (gi *GitInfo) {
+		gi.SSHCommand = sshCommand
 	})
 }
 

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -8,6 +8,7 @@ const AttrKnownSSHHosts = "git.knownsshhosts"
 const AttrMountSSHSock = "git.mountsshsock"
 const AttrGitLFSInclude = "git.lfsinclude" // earthly-specific
 const AttrGitLogLevel = "git.loglevel"     // earthly-specific
+const AttrGitSSHCommand = "git.sshCommand" // earthly-specific
 const AttrLocalSessionID = "local.session"
 const AttrLocalUniqueID = "local.unique"
 const AttrIncludePatterns = "local.includepattern"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -31,6 +31,7 @@ const (
 	CapSourceGitSubdir        apicaps.CapID = "source.git.subdir"
 	CapSourceGitLFSInclude    apicaps.CapID = "source.git.lfsinclude" // earthly-specific
 	CapSourceGitLogLevel      apicaps.CapID = "source.git.logLevel"   // earthly-specific
+	CapSourceGitSSHCommand    apicaps.CapID = "source.git.sshCommand" // earthly-specific
 
 	CapSourceHTTP         apicaps.CapID = "source.http"
 	CapSourceHTTPChecksum apicaps.CapID = "source.http.checksum"
@@ -214,6 +215,12 @@ func init() {
 		Status:  apicaps.CapStatusExperimental,
 	})
 
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceGitSSHCommand,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+	
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceHTTP,
 		Enabled: true,

--- a/source/git/identifier.go
+++ b/source/git/identifier.go
@@ -20,6 +20,7 @@ type GitIdentifier struct {
 	AuthHeaderSecret string
 	MountSSHSock     string
 	KnownSSHHosts    string
+	SSHCommand       string              // earthly-specific
 	LFSInclude       string              // earthly-specific
 	LogLevel         gitutil.GitLogLevel // earthly-specific
 }

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -101,6 +101,8 @@ func (gs *gitSource) Identifier(scheme, ref string, attrs map[string]string, pla
 				return nil, errors.Wrapf(err, "invalid git log level %s", v)
 			}
 			id.LogLevel = gitutil.GitLogLevel(l)
+		case pb.AttrGitSSHCommand: // earthly-specific
+			id.SSHCommand = v
 		}
 	}
 
@@ -699,11 +701,17 @@ func (gs *gitSourceHandler) gitCli(ctx context.Context, g session.Group, opts ..
 		cleanups = append(cleanups, unmountKnownHosts)
 	}
 
+	var sshCommand string
+	if gs.src.SSHCommand != "" {
+		sshCommand = gs.src.SSHCommand
+	}
+
 	opts = append([]gitutil.Option{
 		gitutil.WithGitDir(gitDir),
 		gitutil.WithArgs(gs.authArgs...),
 		gitutil.WithSSHAuthSock(sock),
 		gitutil.WithSSHKnownHosts(knownHosts),
+		gitutil.WithSSHCommand(sshCommand),
 	}, opts...)
 	return gitCLI(opts...), cleanup, err
 }


### PR DESCRIPTION
This PR contains updates to the Earthly buildkit fork in support of earthly/earthly#3499.

- Adds a `WithSSHCommand` function to util/gitutil
- Adds `SSHCommand` function to client/llb
- Adds `git.sshCommand` attribute to solver
- Adds `source.git.sshCommand` capability to solver