### PR TITLE
Cache IDs & fix BK result caching

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -843,6 +843,7 @@ func newController(c *cli.Context, cfg *config.Config, shutdownCh chan struct{})
 		LeaseManager:              w.LeaseManager(),
 		ContentStore:              w.ContentStore(),
 		HistoryConfig:             cfg.History,
+		RootDir:                   cfg.Root,
 	})
 }
 

--- a/control/control.go
+++ b/control/control.go
@@ -68,6 +68,7 @@ type Opt struct {
 	LeaseManager              *leaseutil.Manager
 	ContentStore              *containerdsnapshot.Store
 	HistoryConfig             *config.HistoryConfig
+	RootDir                   string
 }
 
 type Controller struct { // TODO: ControlService
@@ -105,6 +106,7 @@ func NewController(opt Opt) (*Controller, error) {
 		SessionManager:   opt.SessionManager,
 		Entitlements:     opt.Entitlements,
 		HistoryQueue:     hq,
+		RootDir:          opt.RootDir,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create solver")

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -621,6 +621,11 @@ func (j *Job) CloseProgress() {
 }
 
 func (j *Job) Discard() error {
+	// TMP: Hack to prevent actives map deletes.
+	if true {
+		return nil
+	}
+
 	j.list.mu.Lock()
 	defer j.list.mu.Unlock()
 

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
@@ -960,7 +959,6 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 		}()
 
 		res, err := op.Exec(ctx, s.st, inputs)
-		spew.Dump(err)
 		complete := true
 		if err != nil {
 			select {

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
@@ -954,6 +955,7 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 		}()
 
 		res, err := op.Exec(ctx, s.st, inputs)
+		spew.Dump(err)
 		complete := true
 		if err != nil {
 			select {

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -256,8 +256,10 @@ type Job struct {
 }
 
 type SolverOpt struct {
-	ResolveOpFunc ResolveOpFunc
-	DefaultCache  CacheManager
+	ResolveOpFunc      ResolveOpFunc
+	DefaultCache       CacheManager
+	WorkerResultGetter workerResultGetter
+	CommitRefFunc      CommitRefFunc
 }
 
 func NewSolver(opts SolverOpt) *Solver {
@@ -274,7 +276,11 @@ func NewSolver(opts SolverOpt) *Solver {
 	// TODO: This should be hoisted up a few layers as not to be bound to the
 	// original solver. For now, we just need a convenient place to initialize
 	// it once.
-	simple := newSimpleSolver(opts.ResolveOpFunc, jl)
+	c, err := newDiskCache(opts.WorkerResultGetter)
+	if err != nil {
+		panic(err) // TODO: Handle error appropriately once the new solver code is moved.
+	}
+	simple := newSimpleSolver(opts.ResolveOpFunc, opts.CommitRefFunc, jl, c)
 	jl.simple = simple
 
 	jl.s = newScheduler(jl)

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -260,6 +260,7 @@ type SolverOpt struct {
 	DefaultCache       CacheManager
 	WorkerResultGetter workerResultGetter
 	CommitRefFunc      CommitRefFunc
+	RootDir            string
 }
 
 func NewSolver(opts SolverOpt) *Solver {
@@ -276,7 +277,7 @@ func NewSolver(opts SolverOpt) *Solver {
 	// TODO: This should be hoisted up a few layers as not to be bound to the
 	// original solver. For now, we just need a convenient place to initialize
 	// it once.
-	c, err := newDiskCache(opts.WorkerResultGetter)
+	c, err := newDiskCache(opts.WorkerResultGetter, opts.RootDir)
 	if err != nil {
 		panic(err) // TODO: Handle error appropriately once the new solver code is moved.
 	}

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -269,6 +269,9 @@ func captureProvenance(ctx context.Context, res solver.CachedResultWithProvenanc
 		switch op := pp.(type) {
 		case *ops.SourceOp:
 			id, pin := op.Pin()
+			if pin == "" { // Hack: latest cache opt changes led to an empty value here. Investigate.
+				return nil
+			}
 			err := id.Capture(c, pin)
 			if err != nil {
 				return err

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -119,8 +119,10 @@ func New(opt Opt) (*Solver, error) {
 	s.sysSampler = sampler
 
 	s.solver = solver.NewSolver(solver.SolverOpt{
-		ResolveOpFunc: s.resolver(),
-		DefaultCache:  opt.CacheManager,
+		ResolveOpFunc:      s.resolver(),
+		DefaultCache:       opt.CacheManager,
+		WorkerResultGetter: worker.NewWorkerResultGetter(opt.WorkerController),
+		CommitRefFunc:      worker.FinalizeRef,
 	})
 	return s, nil
 }

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -79,6 +79,7 @@ type Opt struct {
 	WorkerController *worker.Controller
 	HistoryQueue     *HistoryQueue
 	ResourceMonitor  *resources.Monitor
+	RootDir          string
 }
 
 type Solver struct {
@@ -123,6 +124,7 @@ func New(opt Opt) (*Solver, error) {
 		DefaultCache:       opt.CacheManager,
 		WorkerResultGetter: worker.NewWorkerResultGetter(opt.WorkerController),
 		CommitRefFunc:      worker.FinalizeRef,
+		RootDir:            opt.RootDir,
 	})
 	return s, nil
 }

--- a/solver/simple.go
+++ b/solver/simple.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -425,16 +426,18 @@ type diskCache struct {
 	resultGetter workerResultGetter
 	db           *bolt.DB
 	bucketName   string
+	rootDir      string
 }
 
 type workerResultGetter interface {
 	Get(ctx context.Context, id string) (Result, error)
 }
 
-func newDiskCache(resultGetter workerResultGetter) (*diskCache, error) {
+func newDiskCache(resultGetter workerResultGetter, rootDir string) (*diskCache, error) {
 	c := &diskCache{
 		bucketName:   "ids",
 		resultGetter: resultGetter,
+		rootDir:      rootDir,
 	}
 	err := c.init()
 	if err != nil {
@@ -444,8 +447,7 @@ func newDiskCache(resultGetter workerResultGetter) (*diskCache, error) {
 }
 
 func (c *diskCache) init() error {
-	// TODO: pass in root config directory.
-	db, err := bolt.Open("/tmp/earthly/buildkit/simple.db", 0755, nil)
+	db, err := bolt.Open(filepath.Join(c.rootDir, "ids.db"), 0755, nil)
 	if err != nil {
 		return err
 	}

--- a/solver/simple.go
+++ b/solver/simple.go
@@ -18,6 +18,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+// CommitRefFunc can be used to finalize a Result's ImmutableRef.
 type CommitRefFunc func(ctx context.Context, result Result) error
 
 type simpleSolver struct {

--- a/solver/simple.go
+++ b/solver/simple.go
@@ -83,7 +83,7 @@ func (s *simpleSolver) buildOne(ctx context.Context, d digest.Digest, vertex Ver
 	st.op = op
 
 	// Add cache opts to context as they will be accessed by cache retrieval.
-	ctx = withAncestorCacheOpts(ctx, st)
+	cacheOptsCtx := withAncestorCacheOpts(ctx, st)
 
 	// CacheMap populates required fields in SourceOp.
 	cm, err := op.CacheMap(ctx, int(e.Index))
@@ -101,7 +101,7 @@ func (s *simpleSolver) buildOne(ctx context.Context, d digest.Digest, vertex Ver
 		return nil, err
 	}
 
-	v, ok, err := s.resultCache.get(ctx, cacheKey)
+	v, ok, err := s.resultCache.get(cacheOptsCtx, cacheKey)
 	if err != nil {
 		return nil, err
 	}

--- a/solver/simple.go
+++ b/solver/simple.go
@@ -251,9 +251,10 @@ func (s *simpleSolver) preprocessInputs(ctx context.Context, st *state, vertex V
 		if dep.ComputeDigestFunc != nil {
 			compDigest, err := dep.ComputeDigestFunc(ctx, res, st)
 			if err != nil {
-				return nil, err
+				bklog.G(ctx).Warnf("failed to compute digest: %v", err)
+			} else {
+				scm.deps[i].computed = compDigest.String()
 			}
-			scm.deps[i].computed = compDigest.String()
 		}
 
 		// Add input references to the struct as to link dependencies.

--- a/solver/simple.go
+++ b/solver/simple.go
@@ -83,7 +83,7 @@ func (s *simpleSolver) buildOne(ctx context.Context, d digest.Digest, vertex Ver
 	st.op = op
 
 	// Add cache opts to context as they will be accessed by cache retrieval.
-	cacheOptsCtx := withAncestorCacheOpts(ctx, st)
+	ctx = withAncestorCacheOpts(ctx, st)
 
 	// CacheMap populates required fields in SourceOp.
 	cm, err := op.CacheMap(ctx, int(e.Index))
@@ -101,7 +101,7 @@ func (s *simpleSolver) buildOne(ctx context.Context, d digest.Digest, vertex Ver
 		return nil, err
 	}
 
-	v, ok, err := s.resultCache.get(cacheOptsCtx, cacheKey)
+	v, ok, err := s.resultCache.get(ctx, cacheKey)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/hashicorp/go-multierror"
 	"github.com/moby/buildkit/cache"
@@ -297,6 +298,8 @@ func (w *Worker) LoadRef(ctx context.Context, id string, hidden bool) (cache.Imm
 	ref, err := w.CacheMgr.Get(ctx, id, pg, opts...)
 	var needsRemoteProviders cache.NeedsRemoteProviderError
 	if errors.As(err, &needsRemoteProviders) {
+		fmt.Println("Trying again with cache opts")
+
 		if optGetter := solver.CacheOptGetterOf(ctx); optGetter != nil {
 			var keys []interface{}
 			for _, dgst := range needsRemoteProviders {
@@ -310,6 +313,7 @@ func (w *Worker) LoadRef(ctx context.Context, id string, hidden bool) (cache.Imm
 					}
 				}
 			}
+			spew.Dump(descHandlers)
 			opts = append(opts, descHandlers)
 			ref, err = w.CacheMgr.Get(ctx, id, pg, opts...)
 		}

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/hashicorp/go-multierror"
 	"github.com/moby/buildkit/cache"
@@ -298,8 +297,6 @@ func (w *Worker) LoadRef(ctx context.Context, id string, hidden bool) (cache.Imm
 	ref, err := w.CacheMgr.Get(ctx, id, pg, opts...)
 	var needsRemoteProviders cache.NeedsRemoteProviderError
 	if errors.As(err, &needsRemoteProviders) {
-		fmt.Println("Trying again with cache opts")
-
 		if optGetter := solver.CacheOptGetterOf(ctx); optGetter != nil {
 			var keys []interface{}
 			for _, dgst := range needsRemoteProviders {
@@ -313,7 +310,6 @@ func (w *Worker) LoadRef(ctx context.Context, id string, hidden bool) (cache.Imm
 					}
 				}
 			}
-			spew.Dump(descHandlers)
 			opts = append(opts, descHandlers)
 			ref, err = w.CacheMgr.Get(ctx, id, pg, opts...)
 		}

--- a/worker/simple.go
+++ b/worker/simple.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 
-	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/solver"
 )
@@ -34,7 +33,7 @@ func (w *WorkerResultGetter) Get(ctx context.Context, id string) (solver.Result,
 	ref, err := worker.LoadRef(ctx, refID, false)
 	if err != nil {
 		if cache.IsNotFound(err) {
-			return nil, errdefs.ErrNotFound
+			return nil, solver.ErrRefNotFound
 		}
 		return nil, err
 	}

--- a/worker/simple.go
+++ b/worker/simple.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 )
 
 // WorkerResultGetter abstracts the work involved in loading a Result from a
@@ -33,6 +34,7 @@ func (w *WorkerResultGetter) Get(ctx context.Context, id string) (solver.Result,
 	ref, err := worker.LoadRef(ctx, refID, false)
 	if err != nil {
 		if cache.IsNotFound(err) {
+			bklog.G(ctx).Warnf("could not load ref from worker: %v", err)
 			return nil, solver.ErrRefNotFound
 		}
 		return nil, err

--- a/worker/simple.go
+++ b/worker/simple.go
@@ -1,0 +1,57 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/solver"
+)
+
+// WorkerResultGetter abstracts the work involved in loading a Result from a
+// worker using a ref ID.
+type WorkerResultGetter struct {
+	wc *Controller
+}
+
+// NewWorkerResultGetter creates and returns a new *WorkerResultGetter.
+func NewWorkerResultGetter(wc *Controller) *WorkerResultGetter {
+	return &WorkerResultGetter{wc: wc}
+}
+
+// Get a cached results from a worker.
+func (w *WorkerResultGetter) Get(ctx context.Context, id string) (solver.Result, error) {
+	workerID, refID, err := parseWorkerRef(id)
+	if err != nil {
+		return nil, err
+	}
+
+	worker, err := w.wc.Get(workerID)
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := worker.LoadRef(ctx, refID, false)
+	if err != nil {
+		if cache.IsNotFound(err) {
+			return nil, errdefs.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return NewWorkerRefResult(ref, worker), nil
+}
+
+// FinalizeRef is a convenience function that calls Finalize on a Result's
+// ImmutableRef. The 'worker' package cannot be imported by 'solver' due to an
+// import cycle, so this function is passed in with solver.SolverOpt.
+func FinalizeRef(ctx context.Context, res solver.Result) error {
+	sys := res.Sys()
+	if w, ok := sys.(*WorkerRef); ok {
+		err := w.ImmutableRef.Finalize(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a new BoltDB cache that links computed cache keys to underlying BK "ref" IDs. It also fully wires up the BK worker & ref caching and loads results from there.