### PR TITLE
Allow using default gRPC dialer

### DIFF
--- a/client/client_earthly.go
+++ b/client/client_earthly.go
@@ -32,3 +32,14 @@ func headersStreamInterceptor(kv ...string) grpc.StreamClientInterceptor {
 		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
+
+// WithDefaultGRPCDialer triggers the internal gRPC dialer to be used instead of the buildkit default.
+// This can be important when buildkit server is behind an HTTP connect proxy,
+// since the default dialer in gRPC already knows how to use those.
+func WithDefaultGRPCDialer() ClientOpt {
+	return &withDefaultGRPCDialer{}
+}
+
+type withDefaultGRPCDialer struct{}
+
+func (*withDefaultGRPCDialer) isClientOpt() {}


### PR DESCRIPTION
The builtin dialer in gRPC has support for things like HTTP connect proxy which we need to support BYOC satellites in some environments. Buildkit was previously forcing it's own dialer implementation.