### PR TITLE
Lock ops based on computed key rather than LLB digest

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ResolveOpFunc finds an Op implementation for a Vertex
+// ResolveOpFunc finds an Op implementation for a Vertex.
 type ResolveOpFunc func(Vertex, Builder) (Op, error)
 
 type Builder interface {
@@ -261,6 +261,7 @@ type SolverOpt struct {
 	ResultSource  ResultSource
 	RefIDStore    *RefIDStore
 	CommitRefFunc CommitRefFunc
+	IsRunOnceFunc IsRunOnceFunc
 }
 
 func NewSolver(opts SolverOpt) *Solver {
@@ -280,6 +281,7 @@ func NewSolver(opts SolverOpt) *Solver {
 		solver,
 		opts.RefIDStore,
 		opts.ResultSource,
+		opts.IsRunOnceFunc,
 	)
 	solver.simple = simple
 

--- a/solver/llbsolver/simple.go
+++ b/solver/llbsolver/simple.go
@@ -1,0 +1,29 @@
+package llbsolver
+
+import (
+	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/llbsolver/ops"
+)
+
+// isRunOnce returns a function that can be called to determine if a Vertex
+// contains an operation that must be run at least once per build.
+func (s *Solver) isRunOnceOp() solver.IsRunOnceFunc {
+	return func(v solver.Vertex, b solver.Builder) (bool, error) {
+		w, err := s.resolveWorker()
+		if err != nil {
+			return false, err
+		}
+
+		op, err := w.ResolveOp(v, s.Bridge(b), s.sm)
+		if err != nil {
+			return false, err
+		}
+
+		switch op.(type) {
+		case *ops.SourceOp:
+			return true, nil
+		default:
+			return false, nil
+		}
+	}
+}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -144,6 +144,7 @@ func New(opt Opt) (*Solver, error) {
 
 	s.solver = solver.NewSolver(solver.SolverOpt{
 		ResolveOpFunc: s.resolver(),
+		IsRunOnceFunc: s.isRunOnceOp(),
 		DefaultCache:  opt.CacheManager,
 		ResultSource:  sources,
 		CommitRefFunc: worker.FinalizeRef,


### PR DESCRIPTION
This PR fixes a few issues with how source ops are run. They need to be run once per build & kept in a "mutable" state to reuse content checksum data across builds. See comments for more details. 

Earthly tests: https://github.com/earthly/earthly/actions/runs/9196103317